### PR TITLE
feat: Contribution Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# KubeArchive Contribution Guide
+
+Welcome to the KubeArchive project!
+We are happy that you find this project interesting and want to improve it.
+Before submitting contributions, please read the following guidelines:
+
+## Writing Pull Requests
+
+Contributions can be submitted by creating a pull request on Github.
+We recommend you do the following to ensure the maintainers can collaborate on your contribution:
+
+* Fork the project into your personal Github account.
+* Create a new feature branch for your contribution.
+* Save and commit your changes:
+  * Add a `Signed-off-by` footer to each commit message to certify the origin of your work.
+  * Use of [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) messages
+    is encouraged, but not required.
+* Create a pull request with a clear title, description, and any other fields described in the pull
+  request template. Include a reference to a GitHub issue if the pull request implements or fixes
+  the issue.
+
+## Developer's Certificate of Origin
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
Add a global contribution guide to the organization. By adding a contribution guide to .github, this becomes the de-facto contribution guide for all repositories within the organization.